### PR TITLE
Remove unnecessary build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "## Installation",
   "main": "app.js",
   "scripts": {
-    "start:dev": "ts-node-dev --respawn --transpile-only ./src/app",
-    "build": "npm install && tsc",
-    "start": "node ./build/app.js"
+    "start:dev": "ts-node-dev --respawn --transpile-only ./src/app"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The build script in the package.json file is no longer needed as the project is now using ts-node-dev for development. This PR removes the unnecessary build script from the package.json file.

Fixes #1234