### PR TITLE
Feat: Implement events registration feature

### DIFF
--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -6,6 +6,7 @@ import {
   getAllEventsController,
   editEventController,
   deleteEventController,
+  registerForEventController,
 } from "../controllers/events.controller";
 import { upload } from "../services/events.service";
 
@@ -32,6 +33,9 @@ eventsRouter.put("/events/edit/:eventID", editEventController);
 
 // Delete an event route
 eventsRouter.delete("/events/delete/:eventID", deleteEventController);
+
+// Register for an event route
+eventsRouter.post("/events/register", registerForEventController);
 
 /**
  * @swagger
@@ -205,6 +209,8 @@ eventsRouter.delete("/events/delete/:eventID", deleteEventController);
  *     summary: Delete an event by ID
  *     tags:
  *       - Events
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: eventID
@@ -252,6 +258,75 @@ eventsRouter.delete("/events/delete/:eventID", deleteEventController);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/NotFoundErrorResponse'
+ * /api/v1/events/register:
+ *   post:
+ *     summary: Register for an event
+ *     tags: [Events]
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               eventID:
+ *                 type: string
+ *                 format: uuid
+ *                 description: The ID of the event to register for
+ *               userID:
+ *                 type: string
+ *                 format: uuid
+ *                 description: The ID of the user registering for the event
+ *     responses:
+ *       '200':
+ *         description: User registered for the event successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 eventID:
+ *                   type: string
+ *                   format: uuid
+ *                   description: The ID of the event
+ *                 title:
+ *                   type: string
+ *                   description: The title of the event
+ *                 description:
+ *                   type: string
+ *                   description: The description of the event
+ *                 participants:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       userID:
+ *                         type: string
+ *                         format: uuid
+ *                         description: The ID of the registered user
+ *                 message:
+ *                   type: string
+ *                   description: A message describing the response
+ *               example:
+ *                 eventID: "123e4567-e89b-12d3-a456-426614174001"
+ *                 title: "Sample Event"
+ *                 description: "This is a sample event."
+ *                 participants: [{ userID: "98765432-abcdef-1234-5678-fedcba987654" }]
+ *                 message: "You have been registered for this event."
+ *       '404':
+ *         description: Event not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/NotFoundErrorResponse'
+ *       '409':
+ *         description: Conflict - User already registered for the event
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ConflictErrorResponse'
  */
 
 /**
@@ -398,6 +473,27 @@ eventsRouter.delete("/events/delete/:eventID", deleteEventController);
  *         timestamp: "2021-01-01T00:00:00.000Z"
  *         success: false
  *         status: 404
+ *         message: "Sample error message"
+ *     ConflictErrorResponse:
+ *       type: object
+ *       properties:
+ *         timestamp:
+ *           type: string
+ *           format: date-time
+ *           description: The date and time of the response in ISO 8601 format
+ *         success:
+ *           type: boolean
+ *           description: Whether the request was successful or not
+ *         status:
+ *           type: number
+ *           description: The status code of the response
+ *         message:
+ *           type: string
+ *           description: A message describing the response
+ *       example:
+ *         timestamp: "2021-01-01T00:00:00.000Z"
+ *         success: false
+ *         status: 409
  *         message: "Sample error message"
  */
 


### PR DESCRIPTION
**Feat: Implement events registration feature.**
​
## Description
<!--- Describe your changes in detail -->
I implemented the endpoint to update the fields of an event.
​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue : -->
Closes #9  
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This feature allows users to register for an event.
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with Postman.
​
## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/hngx-org/Evento/assets/87391935/88648539-7182-4080-8437-040785469705)

![image](https://github.com/hngx-org/Evento/assets/87391935/55d17717-cecf-46fd-b164-c055cc40a1a8)
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.