### PR TITLE
Fix email comparison in generateOTP function

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -235,7 +235,7 @@ export const generateOTP = async (
 ) => {
   try {
     const userID = req.params.id;
-    const { compareEmail } = req.body;
+    const { email } = req.body;
 
     console.log(userID);
     const user = await prisma.user.findUnique({
@@ -253,6 +253,10 @@ export const generateOTP = async (
     if (!user) {
       throw new BadRequestError("User does not exist");
     }
+
+    const compareEmail = email;
+
+    console.log(user.email, compareEmail);
 
     if (user.email !== compareEmail) {
       throw new BadRequestError("Please use a registered email");


### PR DESCRIPTION
This pull request fixes a bug in the generateOTP function where the email comparison was not working correctly. The function now correctly compares the user's email with the provided email. This ensures that only registered emails can be used to generate an OTP.