### PR TITLE
Add deleteUserProfileImage controller and route

### DIFF
--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -11,6 +11,7 @@ import {
   updateUserPreferences,
   deleteUser,
   updateUserPassword,
+  deleteUserProfileImage,
 } from "./../controllers/user.controller";
 
 const router: Router = express.Router();
@@ -400,5 +401,31 @@ router.delete("/user/delete/:id", deleteUser);
  *               type: string
  */
 router.post("/user/password/change/:id", updateUserPassword);
+
+/**
+ * @swagger
+ * /api/v1/user/profile/image/delete/{id}:
+ *   delete:
+ *     summary: Delete User Profile Image by ID
+ *     description: Delete user profile image by user ID.
+ *     tags: [User]
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID of the user profile to delete profile image
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
+router.delete("/user/profile/image/delete/:id", deleteUserProfileImage);
 
 module.exports = router;

--- a/src/services/imageupload.ts
+++ b/src/services/imageupload.ts
@@ -35,9 +35,24 @@ export const cloudinaryService = async (
     urls.push(image.secure_url);
 
     return { successful: true, message: "file uploaded successfully", urls };
-
-    return { successful: true, message: "files uploaded successfully", urls };
   } catch (error) {
     return { successful: false, message: (error as Error).message, urls: [] };
+  }
+};
+
+// delete image from cloudinary
+export const deleteImage = async (public_id: string) => {
+  try {
+    cloudinary.config({
+      cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+      api_key: process.env.CLOUDINARY_API_KEY,
+      api_secret: process.env.CLOUDINARY_API_SECRET,
+    });
+
+    const result = await cloudinary.v2.uploader.destroy(public_id);
+
+    return { successful: true, message: "file deleted successfully", result };
+  } catch (error) {
+    return { successful: false, message: (error as Error).message, result: {} };
   }
 };


### PR DESCRIPTION
This pull request adds a new controller and route for deleting a user's profile image. The deleteUserProfileImage controller handles the deletion of the image from the cloud storage and updates the user's profile image field in the database. This feature allows users to easily delete their profile images when needed.