### PR TITLE
Updated swagger docs

### DIFF
--- a/src/interfaces/notification.interface.ts
+++ b/src/interfaces/notification.interface.ts
@@ -1,0 +1,35 @@
+interface NotificationPreference {
+    newsletter: {
+        inApp: boolean;
+        email: boolean;
+        push: boolean;
+    };
+    event_registration: {
+        inApp: boolean;
+        email: boolean;
+        push: boolean;
+    };
+    event_invite: {
+        inApp: boolean;
+        email: boolean;
+        push: boolean;
+    };
+    join_event: {
+        inApp: boolean;
+        email: boolean;
+        push: boolean;
+    };
+    event_change: {
+        inApp: boolean;
+        email: boolean;
+        push: boolean;
+    };
+}
+
+interface Preference {
+    inApp: boolean;
+    email: boolean;
+    push: boolean;
+}
+
+export {NotificationPreference, Preference}

--- a/src/routes/notifications.route.ts
+++ b/src/routes/notifications.route.ts
@@ -1,9 +1,272 @@
 import { Router } from 'express';
-import { updateNotificationPreferences } from '../controllers/notifications.controller';
+import { updateNotificationPreferences, getNotificationPreferences } from '../controllers/notifications.controller';
 
 const router  = Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Notification Preferences
+ *   description: Notification Preferences Endpoints
+ *
+ * /api/v1/settings/{userId}/notifications:
+ *   get:
+ *     summary: Get notification preferences for a user
+ *     tags: [Notification Preferences]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The ID of the user
+ *     responses:
+ *       '200':
+ *         description: Notification preferences retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               description: User's notification preferences
+ *               properties:
+ *                 newsletter:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                       description: Whether in-app notifications are enabled for newsletters
+ *                     email:
+ *                       type: boolean
+ *                       description: Whether email notifications are enabled for newsletters
+ *                     push:
+ *                       type: boolean
+ *                       description: Whether push notifications are enabled for newsletters
+ *                   example:
+ *                     inApp: true
+ *                     email: true
+ *                     push: false
+ *                 event_registration:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                       description: Whether in-app notifications are enabled for event registrations
+ *                     email:
+ *                       type: boolean
+ *                       description: Whether email notifications are enabled for event registrations
+ *                     push:
+ *                       type: boolean
+ *                       description: Whether push notifications are enabled for event registrations
+ *                   example:
+ *                     inApp: true
+ *                     email: false
+ *                     push: true
+ *                 event_invite:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                       description: Whether in-app notifications are enabled for event invites
+ *                     email:
+ *                       type: boolean
+ *                       description: Whether email notifications are enabled for event invites
+ *                     push:
+ *                       type: boolean
+ *                       description: Whether push notifications are enabled for event invites
+ *                   example:
+ *                     inApp: true
+ *                     email: false
+ *                     push: false
+ *                 join_event:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                       description: Whether in-app notifications are enabled for joining events
+ *                     email:
+ *                       type: boolean
+ *                       description: Whether email notifications are enabled for joining events
+ *                     push:
+ *                       type: boolean
+ *                       description: Whether push notifications are enabled for joining events
+ *                   example:
+ *                     inApp: false
+ *                     email: true
+ *                     push: true
+ *                 event_change:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                       description: Whether in-app notifications are enabled for event changes
+ *                     email:
+ *                       type: boolean
+ *                       description: Whether email notifications are enabled for event changes
+ *                     push:
+ *                       type: boolean
+ *                       description: Whether push notifications are enabled for event changes
+ *                   example:
+ *                     inApp: true
+ *                     email: true
+ *                     push: true
+ *               example:
+ *                 newsletter:
+ *                   inApp: true
+ *                   email: true
+ *                   push: false
+ *                 event_registration:
+ *                   inApp: true
+ *                   email: false
+ *                   push: true
+ *                 event_invite:
+ *                   inApp: true
+ *                   email: false
+ *                   push: false
+ *                 join_event:
+ *                   inApp: false
+ *                   email: true
+ *                   push: true
+ *                 event_change:
+ *                   inApp: true
+ *                   email: true
+ *                   push: true
+ *       '404':
+ *         description: User not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/NotFoundErrorResponse'
+ *   post:
+ *     summary: Update notification preferences for a user
+ *     tags: [Notification Preferences]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The ID of the user
+ *       - in: body
+ *         name: preferences
+ *         description: The notification preferences to update
+ *         required: true
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/NotificationPreference'
+ *     responses:
+ *       '200':
+ *         description: Notification preferences updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               description: Updated notification preferences
+ *               properties:
+ *                 newsletter:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                     email:
+ *                       type: boolean
+ *                     push:
+ *                       type: boolean
+ *                   example:
+ *                     inApp: true
+ *                     email: true
+ *                     push: false
+ *                 event_registration:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                     email:
+ *                       type: boolean
+ *                     push:
+ *                       type: boolean
+ *                   example:
+ *                     inApp: true
+ *                     email: false
+ *                     push: true
+ *                 event_invite:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                     email:
+ *                       type: boolean
+ *                     push:
+ *                       type: boolean
+ *                   example:
+ *                     inApp: true
+ *                     email: false
+ *                     push: false
+ *                 join_event:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                     email:
+ *                       type: boolean
+ *                     push:
+ *                       type: boolean
+ *                   example:
+ *                     inApp: false
+ *                     email: true
+ *                     push: true
+ *                 event_change:
+ *                   type: object
+ *                   properties:
+ *                     inApp:
+ *                       type: boolean
+ *                     email:
+ *                       type: boolean
+ *                     push:
+ *                       type: boolean
+ *                   example:
+ *                     inApp: true
+ *                     email: true
+ *                     push: true
+ *               example:
+ *                 newsletter:
+ *                   inApp: true
+ *                   email: true
+ *                   push: false
+ *                 event_registration:
+ *                   inApp: true
+ *                   email: false
+ *                   push: true
+ *                 event_invite:
+ *                   inApp: true
+ *                   email: false
+ *                   push: false
+ *                 join_event:
+ *                   inApp: false
+ *                   email: true
+ *                   push: true
+ *                 event_change:
+ *                   inApp: true
+ *                   email: true
+ *                   push: true
+ *       '404':
+ *         description: User not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/NotFoundErrorResponse'
+ *       '500':
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalServerErrorResponse'
+ */
+
+
 
 router.post('/settings/:userId/notifications', updateNotificationPreferences);
+
+router.get('/settings/:userId/notifications', getNotificationPreferences);
 
 module.exports = router;

--- a/src/routes/notifications.route.ts
+++ b/src/routes/notifications.route.ts
@@ -265,7 +265,7 @@ const router  = Router();
 
 
 
-router.post('/settings/:userId/notifications', updateNotificationPreferences);
+router.put('/settings/:userId/notifications', updateNotificationPreferences);
 
 router.get('/settings/:userId/notifications', getNotificationPreferences);
 


### PR DESCRIPTION
## Title: Implement Notification Preferences Update Endpoint

### Description:

**Changes Made:**

1. Added documentation for GET and PUT notification preferences endpoints.
2. Added a swagger docs for `GET /settings/:userId/notifications` endpoint to get all user notification preferences.
3. Added a swagger docs for `PUT /settings/:userId/notifications` endpoint to update all user notification preferences.
4. Moved interfaces to `/interfaces directory`

### How to Test:
Send PUT Request to: `http://localhost:3000/api/v1/settings/:userId/notifications`
Send GET Request to: `http://localhost:3000/api/v1/settings/:userId/notifications`
1. [x] The new endpoint is reachable and accepts the expected payload.
2. [x] Error handling works as expected for cases where a record does not exist.

### Screenshots:
Screenshots or images demonstrating the changes
![image](https://github.com/hngx-org/Evento/assets/51229609/9c76e8cd-0cf5-4818-bfd7-5236f446ed7e)


### Additional Notes:

- None
