### PR TITLE
Add coverImage field to getUserProfileById query

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -104,6 +104,7 @@ const getUserProfileById = async (
         slug: true,
         role: true,
         location: true,
+        coverImage: true,
       },
     });
 


### PR DESCRIPTION
This pull request adds the coverImage field to the getUserProfileById query, allowing users to retrieve the cover image associated with a user's profile.