### PR TITLE
Update token expiration to 3 days

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -152,7 +152,7 @@ export const login = async (
         id: user.userID,
       };
       const token = jwt.sign(userWithoutPassword, process.env.JWT_SECRET, {
-        expiresIn: "1h",
+        expiresIn: "3 days",
       });
       if (err) {
         return next(err);


### PR DESCRIPTION
This pull request updates the token expiration to 3 days instead of 1 hour. This change provides a longer validity period for user authentication.