### PR TITLE
Add optional flag to location field in createEventSchema

### DIFF
--- a/src/middlewares/validations/events.zod.ts
+++ b/src/middlewares/validations/events.zod.ts
@@ -63,7 +63,8 @@ export const createEventSchema = z.object({
       .string({
         invalid_type_error: "Location must be a string.",
       })
-      .min(5, { message: "Location must be at least 5 characters long." }),
+      .min(5, { message: "Location must be at least 5 characters long." })
+      .optional(),
     virtualLocationLink: z
       .string({
         required_error: "Please provide a virtual location link for the event.",


### PR DESCRIPTION
This pull request adds an optional flag to the location field in the createEventSchema. Previously, the location field was required and had a minimum length of 5 characters. With this change, the location field can now be left empty if needed.